### PR TITLE
Optimize Prettier Configuration

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,6 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
-  /* config options here */
   reactStrictMode: true,
 };
 

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -5,7 +5,8 @@ const prettierConfig = {
   trailingComma: 'es5',
   printWidth: 120,
   tabWidth: 2,
-  plugins: ['prettier-plugin-tailwindcss', 'prettier-plugin-sort-imports'],
+  // tailwind plugin must be the last one
+  plugins: ['prettier-plugin-sort-imports', 'prettier-plugin-tailwindcss'],
 };
 
 export default prettierConfig;

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -11,8 +11,8 @@ import { Button } from '@/components/ui/button';
 
 export default function Demo() {
   return (
-    <div className="container w-full h-full overflow-auto overscroll-contain">
-      <div className="container mx-auto px-4 py-16 space-y-16 max-w-[1200px]">
+    <div className="container h-full w-full overflow-auto overscroll-contain">
+      <div className="container mx-auto max-w-[1200px] space-y-16 px-4 py-16">
         {/* 页面标题 */}
         <div className="space-y-3">
           <h1 className="text-4xl font-bold tracking-tight">组件展示 </h1>
@@ -30,7 +30,7 @@ export default function Demo() {
           <div className="space-y-8">
             <div className="space-y-4">
               <h3 className="text-xl font-medium">变体 Variants</h3>
-              <div className="flex flex-wrap gap-6 items-center">
+              <div className="flex flex-wrap items-center gap-6">
                 <Button variant="default">Default</Button>
                 <Button variant="destructive">Destructive</Button>
                 <Button variant="outline">Outline</Button>
@@ -199,16 +199,16 @@ export default function Demo() {
                       <DrawerTitle>表单示例</DrawerTitle>
                       <DrawerDescription>这是一个包含表单的抽屉示例。</DrawerDescription>
                     </DrawerHeader>
-                    <div className="p-4 space-y-4">
+                    <div className="space-y-4 p-4">
                       <div className="space-y-2">
                         <label className="text-sm font-medium">用户名</label>
-                        <input type="text" className="w-full px-3 py-2 border rounded-md" placeholder="请输入用户名" />
+                        <input type="text" className="w-full rounded-md border px-3 py-2" placeholder="请输入用户名" />
                       </div>
                       <div className="space-y-2">
                         <label className="text-sm font-medium">密码</label>
                         <input
                           type="password"
-                          className="w-full px-3 py-2 border rounded-md"
+                          className="w-full rounded-md border px-3 py-2"
                           placeholder="请输入密码"
                         />
                       </div>
@@ -234,7 +234,7 @@ export default function Demo() {
                     <div className="p-4">
                       <ul className="space-y-2">
                         {Array.from({ length: 5 }).map((_, i) => (
-                          <li key={i} className="p-3 rounded-lg bg-muted flex items-center justify-between">
+                          <li key={i} className="bg-muted flex items-center justify-between rounded-lg p-3">
                             <span>列表项 {i + 1}</span>
                             <Button variant="ghost" size="sm">
                               操作
@@ -256,7 +256,7 @@ export default function Demo() {
         </section>
 
         {/* 这里可以添加更多组件展示区域 */}
-        <div className="h-[300px] flex items-center justify-center border-2 border-dashed rounded-xl border-muted-foreground/20">
+        <div className="border-muted-foreground/20 flex h-[300px] items-center justify-center rounded-xl border-2 border-dashed">
           <p className="text-muted-foreground text-lg">更多组件即将添加...</p>
         </div>
       </div>

--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -2,24 +2,24 @@ import { FC } from 'react';
 
 const DiscoverPage: FC = () => {
   return (
-    <div className="container w-full h-full overflow-auto overscroll-contain">
-      <h1 className="text-2xl font-bold p-4 md:p-6 mb-4 md:mb-6">发现</h1>
+    <div className="container h-full w-full overflow-auto overscroll-contain">
+      <h1 className="mb-4 p-4 text-2xl font-bold md:mb-6 md:p-6">发现</h1>
 
       <div className="flex flex-col gap-4 md:gap-6">
         <section>
-          <h2 className="text-xl font-semibold px-4 md:px-6 mb-3 md:mb-4">推荐食谱</h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 px-4 md:px-6 gap-3 md:gap-4">
+          <h2 className="mb-3 px-4 text-xl font-semibold md:mb-4 md:px-6">推荐食谱</h2>
+          <div className="grid grid-cols-1 gap-3 px-4 md:grid-cols-2 md:gap-4 md:px-6">
             {Array.from({ length: 4 }).map((_, index) => (
-              <div key={index} className="bg-muted/30 rounded-lg md:p-4 flex flex-col">
-                <div className="h-24 md:h-32 bg-muted/50 rounded-md flex items-center justify-center">食谱图片</div>
+              <div key={index} className="bg-muted/30 flex flex-col rounded-lg md:p-4">
+                <div className="bg-muted/50 flex h-24 items-center justify-center rounded-md md:h-32">食谱图片</div>
                 <div className="p-2">
-                  <h3 className="font-medium text-sm md:text-base truncate">健康食谱 {index + 1}</h3>
-                  <p className="text-xs md:text-sm text-muted-foreground mt-1 line-clamp-2">
+                  <h3 className="truncate text-sm font-medium md:text-base">健康食谱 {index + 1}</h3>
+                  <p className="text-muted-foreground mt-1 line-clamp-2 text-xs md:text-sm">
                     这是一道美味又健康的食谱，富含蛋白质和维生素。
                   </p>
-                  <div className="mt-2 text-xs md:text-sm flex flex-wrap gap-1">
-                    <span className="inline-block bg-primary/10 text-primary rounded-full px-2 py-0.5">低脂</span>
-                    <span className="inline-block bg-primary/10 text-primary rounded-full px-2 py-0.5">高蛋白</span>
+                  <div className="mt-2 flex flex-wrap gap-1 text-xs md:text-sm">
+                    <span className="bg-primary/10 text-primary inline-block rounded-full px-2 py-0.5">低脂</span>
+                    <span className="bg-primary/10 text-primary inline-block rounded-full px-2 py-0.5">高蛋白</span>
                   </div>
                 </div>
               </div>
@@ -28,27 +28,27 @@ const DiscoverPage: FC = () => {
         </section>
 
         <section className="w-full">
-          <h2 className="text-xl w-full font-semibold px-4 md:px-6 mb-3 md:mb-4">热门食物</h2>
-          <div className="overflow-x-auto w-full px-4 md:px-6 flex flex-row gap-3 min-w-0">
+          <h2 className="mb-3 w-full px-4 text-xl font-semibold md:mb-4 md:px-6">热门食物</h2>
+          <div className="flex w-full min-w-0 flex-row gap-3 overflow-x-auto px-4 md:px-6">
             {Array.from({ length: 20 }).map((_, index) => (
-              <div key={index} className="flex-shrink-0 w-24 md:w-32">
-                <div className="h-24 md:h-32 bg-muted/30 rounded-lg flex items-center justify-center mb-2">
+              <div key={index} className="w-24 flex-shrink-0 md:w-32">
+                <div className="bg-muted/30 mb-2 flex h-24 items-center justify-center rounded-lg md:h-32">
                   食物 {index + 1}
                 </div>
-                <div className="font-medium text-xs md:text-sm truncate">热门食物 {index + 1}</div>
-                <div className="text-xs text-muted-foreground">300 卡路里</div>
+                <div className="truncate text-xs font-medium md:text-sm">热门食物 {index + 1}</div>
+                <div className="text-muted-foreground text-xs">300 卡路里</div>
               </div>
             ))}
           </div>
         </section>
 
         <section>
-          <h2 className="text-xl font-semibold px-4 md:px-6 mb-3 md:mb-4">健康饮食建议</h2>
-          <div className="flex flex-col gap-2 md:gap-3 px-4 md:px-6">
+          <h2 className="mb-3 px-4 text-xl font-semibold md:mb-4 md:px-6">健康饮食建议</h2>
+          <div className="flex flex-col gap-2 px-4 md:gap-3 md:px-6">
             {Array.from({ length: 3 }).map((_, index) => (
-              <div key={index} className="p-3 md:p-4 bg-muted/30 rounded-lg">
-                <h3 className="font-medium mb-1 text-sm md:text-base truncate">饮食建议 {index + 1}</h3>
-                <p className="text-xs md:text-sm text-muted-foreground line-clamp-3">
+              <div key={index} className="bg-muted/30 rounded-lg p-3 md:p-4">
+                <h3 className="mb-1 truncate text-sm font-medium md:text-base">饮食建议 {index + 1}</h3>
+                <p className="text-muted-foreground line-clamp-3 text-xs md:text-sm">
                   这是一条基于您的饮食习惯和健康目标的个性化建议，帮助您保持健康的生活方式。
                 </p>
               </div>
@@ -56,7 +56,7 @@ const DiscoverPage: FC = () => {
           </div>
         </section>
 
-        <div className="w-full h-4 md:h-6"></div>
+        <div className="h-4 w-full md:h-6"></div>
       </div>
     </div>
   );

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -2,27 +2,27 @@ import { FC } from 'react';
 
 const HistoryPage: FC = () => {
   return (
-    <div className="container w-full h-full overflow-auto overscroll-contain">
-      <h1 className="text-2xl font-bold p-4 md:p-6 mb-4 md:mb-6">历史</h1>
+    <div className="container h-full w-full overflow-auto overscroll-contain">
+      <h1 className="mb-4 p-4 text-2xl font-bold md:mb-6 md:p-6">历史</h1>
 
       <div className="space-y-6 px-4 md:px-6">
         <div>
-          <h2 className="text-xl font-semibold mb-4">历史数据</h2>
-          <div className="h-64 bg-muted/30 rounded-lg flex items-center justify-center">历史数据图表区域</div>
+          <h2 className="mb-4 text-xl font-semibold">历史数据</h2>
+          <div className="bg-muted/30 flex h-64 items-center justify-center rounded-lg">历史数据图表区域</div>
         </div>
 
         <div>
-          <h2 className="text-xl font-semibold mb-4">历史记录</h2>
+          <h2 className="mb-4 text-xl font-semibold">历史记录</h2>
           <div className="space-y-2">
             {Array.from({ length: 5 }).map((_, index) => (
-              <div key={index} className="p-4 bg-muted/30 rounded-lg flex justify-between items-center">
+              <div key={index} className="bg-muted/30 flex items-center justify-between rounded-lg p-4">
                 <div>
                   <div className="font-medium">记录 {index + 1}</div>
-                  <div className="text-sm text-muted-foreground">2023-03-{String(index + 1).padStart(2, '0')}</div>
+                  <div className="text-muted-foreground text-sm">2023-03-{String(index + 1).padStart(2, '0')}</div>
                 </div>
                 <div className="text-right">
                   <div>2000 卡路里</div>
-                  <div className="text-sm text-muted-foreground">蛋白质: 120g</div>
+                  <div className="text-muted-foreground text-sm">蛋白质: 120g</div>
                 </div>
               </div>
             ))}
@@ -30,7 +30,7 @@ const HistoryPage: FC = () => {
         </div>
       </div>
 
-      <div className="w-full h-4 md:h-6"></div>
+      <div className="h-4 w-full md:h-6"></div>
     </div>
   );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,26 +2,26 @@ import { FC } from 'react';
 
 const HomePage: FC = () => {
   return (
-    <div className="container w-full h-full overflow-auto overscroll-contain">
-      <h1 className="text-2xl font-bold p-4 md:p-6 mb-4 md:mb-6">今日</h1>
+    <div className="container h-full w-full overflow-auto overscroll-contain">
+      <h1 className="mb-4 p-4 text-2xl font-bold md:mb-6 md:p-6">今日</h1>
 
       <div className="space-y-6 px-4 md:px-6">
         <div>
-          <h2 className="text-xl font-semibold mb-4">今日摄入</h2>
-          <div className="h-64 bg-muted/30 rounded-lg flex items-center justify-center">今日数据图表区域</div>
+          <h2 className="mb-4 text-xl font-semibold">今日摄入</h2>
+          <div className="bg-muted/30 flex h-64 items-center justify-center rounded-lg">今日数据图表区域</div>
         </div>
 
         <div>
-          <h2 className="text-xl font-semibold mb-4">营养摄入分析</h2>
+          <h2 className="mb-4 text-xl font-semibold">营养摄入分析</h2>
           <div className="space-y-4">
-            <div className="p-4 bg-muted/30 rounded-lg">营养素分析 1</div>
-            <div className="p-4 bg-muted/30 rounded-lg">营养素分析 2</div>
-            <div className="p-4 bg-muted/30 rounded-lg">营养素分析 3</div>
+            <div className="bg-muted/30 rounded-lg p-4">营养素分析 1</div>
+            <div className="bg-muted/30 rounded-lg p-4">营养素分析 2</div>
+            <div className="bg-muted/30 rounded-lg p-4">营养素分析 3</div>
           </div>
         </div>
       </div>
 
-      <div className="w-full h-4 md:h-6"></div>
+      <div className="h-4 w-full md:h-6"></div>
     </div>
   );
 };

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,89 +3,89 @@ import { FC } from 'react';
 
 const SettingsPage: FC = () => {
   return (
-    <div className="container w-full h-full overflow-auto overscroll-contain">
-      <h1 className="text-2xl font-bold p-4 md:p-6 mb-4 md:mb-6">设置</h1>
+    <div className="container h-full w-full overflow-auto overscroll-contain">
+      <h1 className="mb-4 p-4 text-2xl font-bold md:mb-6 md:p-6">设置</h1>
 
       <div className="space-y-6 px-4 md:px-6">
         <div>
-          <h2 className="text-xl font-semibold mb-4">应用设置</h2>
+          <h2 className="mb-4 text-xl font-semibold">应用设置</h2>
           <div className="space-y-4">
-            <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
+            <div className="bg-muted/30 flex items-center justify-between rounded-lg p-4">
               <div>
                 <div className="font-medium">主题</div>
-                <div className="text-sm text-muted-foreground">切换应用的明暗主题</div>
+                <div className="text-muted-foreground text-sm">切换应用的明暗主题</div>
               </div>
               <ThemeToggle />
             </div>
 
-            <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
+            <div className="bg-muted/30 flex items-center justify-between rounded-lg p-4">
               <div>
                 <div className="font-medium">语言</div>
-                <div className="text-sm text-muted-foreground">选择应用的显示语言</div>
+                <div className="text-muted-foreground text-sm">选择应用的显示语言</div>
               </div>
-              <select className="bg-background border rounded-md px-3 py-1">
+              <select className="bg-background rounded-md border px-3 py-1">
                 <option value="zh">中文</option>
                 <option value="en">English</option>
               </select>
             </div>
 
-            <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
+            <div className="bg-muted/30 flex items-center justify-between rounded-lg p-4">
               <div>
                 <div className="font-medium">通知</div>
-                <div className="text-sm text-muted-foreground">管理应用的通知设置</div>
+                <div className="text-muted-foreground text-sm">管理应用的通知设置</div>
               </div>
-              <div className="relative inline-flex h-6 w-11 items-center rounded-full bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background">
-                <span className="inline-block h-5 w-5 translate-x-1 rounded-full bg-background transition-transform" />
+              <div className="bg-muted focus-visible:ring-ring focus-visible:ring-offset-background relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none">
+                <span className="bg-background inline-block h-5 w-5 translate-x-1 rounded-full transition-transform" />
               </div>
             </div>
           </div>
         </div>
 
         <div>
-          <h2 className="text-xl font-semibold mb-4">个人信息</h2>
+          <h2 className="mb-4 text-xl font-semibold">个人信息</h2>
           <div className="space-y-4">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div>
-                <label className="block text-sm font-medium mb-1">姓名</label>
+                <label className="mb-1 block text-sm font-medium">姓名</label>
                 <input
                   type="text"
-                  className="w-full px-3 py-2 border rounded-md bg-background"
+                  className="bg-background w-full rounded-md border px-3 py-2"
                   placeholder="请输入姓名"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">年龄</label>
+                <label className="mb-1 block text-sm font-medium">年龄</label>
                 <input
                   type="number"
-                  className="w-full px-3 py-2 border rounded-md bg-background"
+                  className="bg-background w-full rounded-md border px-3 py-2"
                   placeholder="请输入年龄"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">身高 (cm)</label>
+                <label className="mb-1 block text-sm font-medium">身高 (cm)</label>
                 <input
                   type="number"
-                  className="w-full px-3 py-2 border rounded-md bg-background"
+                  className="bg-background w-full rounded-md border px-3 py-2"
                   placeholder="请输入身高"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">体重 (kg)</label>
+                <label className="mb-1 block text-sm font-medium">体重 (kg)</label>
                 <input
                   type="number"
-                  className="w-full px-3 py-2 border rounded-md bg-background"
+                  className="bg-background w-full rounded-md border px-3 py-2"
                   placeholder="请输入体重"
                 />
               </div>
             </div>
-            <button className="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:opacity-90 transition-opacity">
+            <button className="bg-primary text-primary-foreground rounded-md px-4 py-2 transition-opacity hover:opacity-90">
               保存设置
             </button>
           </div>
         </div>
       </div>
 
-      <div className="w-full h-4 md:h-6"></div>
+      <div className="h-4 w-full md:h-6"></div>
     </div>
   );
 };

--- a/src/components/app-layout.tsx
+++ b/src/components/app-layout.tsx
@@ -72,7 +72,7 @@ const NavTab: FC<NavTabProps> = ({ tab, variant, pathname, onTabItemClick }) => 
         href={tab.path}
         onClick={handleClick}
         className={cn(
-          'flex items-center gap-3 px-4 py-3 rounded-md transition-colors',
+          'flex items-center gap-3 rounded-md px-4 py-3 transition-colors',
           'text-sidebar-foreground opacity-50',
           { 'hover:opacity-80': !isActive() },
           { 'bg-sidebar-accent opacity-100 hover:opacity-100': isActive() }
@@ -90,12 +90,12 @@ const NavTab: FC<NavTabProps> = ({ tab, variant, pathname, onTabItemClick }) => 
       onClick={handleClick}
       className={cn(
         'text-sidebar-foreground opacity-40 hover:opacity-80',
-        'transition-colors text-xs',
+        'text-xs transition-colors',
         'pb-[env(safe-area-inset-bottom)]',
         { 'opacity-100': isActive() }
       )}
     >
-      <div className="w-full h-full flex flex-col items-center justify-center">
+      <div className="flex h-full w-full flex-col items-center justify-center">
         {tab.icon}
         <span className="mt-1">{tab.label}</span>
       </div>
@@ -117,22 +117,22 @@ interface DesktopSidebarProps {
  */
 const DesktopSidebar: FC<DesktopSidebarProps> = ({ tabs, pathname, onTabItemClick }) => {
   return (
-    <nav className="hidden md:flex flex-col w-56 h-full border-r bg-sidebar shrink-0 grow-0 pl-[env(safe-area-inset-left)]">
-      <div className="px-5 py-4 flex flex-row items-center gap-2">
+    <nav className="bg-sidebar hidden h-full w-56 shrink-0 grow-0 flex-col border-r pl-[env(safe-area-inset-left)] md:flex">
+      <div className="flex flex-row items-center gap-2 px-5 py-4">
         <Beef className="size-6" />
-        <h1 className="text-xl font-semibold text-sidebar-foreground">EatWise</h1>
+        <h1 className="text-sidebar-foreground text-xl font-semibold">EatWise</h1>
       </div>
-      <hr className="h-[1px] bg-sidebar-accent" />
-      <div className="flex flex-col flex-1 p-2 gap-2 overflow-y-auto">
+      <hr className="bg-sidebar-accent h-[1px]" />
+      <div className="flex flex-1 flex-col gap-2 overflow-y-auto p-2">
         {tabs.map((tab) => (
           <NavTab key={tab.id} tab={tab} pathname={pathname} variant="desktop" onTabItemClick={onTabItemClick} />
         ))}
       </div>
-      <div className="px-5 py-4 flex flex-row items-center gap-2">
-        <div className="rounded-full bg-sidebar-accent p-2">
+      <div className="flex flex-row items-center gap-2 px-5 py-4">
+        <div className="bg-sidebar-accent rounded-full p-2">
           <User className="size-5" />
         </div>
-        <div className="text-sm text-sidebar-foreground">John Doe</div>
+        <div className="text-sidebar-foreground text-sm">John Doe</div>
       </div>
     </nav>
   );
@@ -152,9 +152,9 @@ interface MobileNavBarProps {
  */
 const MobileNavBar: FC<MobileNavBarProps> = ({ tabs, pathname, onTabItemClick }) => {
   return (
-    <nav className="fixed md:hidden h-[calc(56px+env(safe-area-inset-bottom))] border-t-[1px] box-content bg-sidebar bottom-0 left-0 right-0 touch-none shrink-0 grow-0">
+    <nav className="bg-sidebar fixed right-0 bottom-0 left-0 box-content h-[calc(56px+env(safe-area-inset-bottom))] shrink-0 grow-0 touch-none border-t-[1px] md:hidden">
       <div
-        className={`h-full w-full grid items-stretch justify-center`}
+        className={`grid h-full w-full items-stretch justify-center`}
         style={useMemo(() => ({ gridTemplateColumns: `repeat(${tabs.length}, 1fr)` }), [tabs.length])}
       >
         {tabs.map((tab) => (
@@ -170,7 +170,7 @@ const MobileNavBar: FC<MobileNavBarProps> = ({ tabs, pathname, onTabItemClick })
  */
 const MobileNavBarPlaceholder: FC = () => {
   return (
-    <div className="md:hidden h-[calc(56px+env(safe-area-inset-bottom))] border-t-[1px] box-content invisible shrink-0 grow-0" />
+    <div className="invisible box-content h-[calc(56px+env(safe-area-inset-bottom))] shrink-0 grow-0 border-t-[1px] md:hidden" />
   );
 };
 
@@ -218,12 +218,12 @@ export const AppLayout: FC<AppLayoutProps> = ({ children }) => {
 
   return (
     <div
-      className="flex flex-col md:flex-row h-full w-full overflow-clip relative bg-background"
+      className="bg-background relative flex h-full w-full flex-col overflow-clip md:flex-row"
       data-vaul-drawer-wrapper
     >
       <DesktopSidebar tabs={tabs} pathname={pathname} onTabItemClick={handleClick} />
-      <main className="flex-1 flex flex-col h-full overflow-clip min-w-0">
-        <div className="flex-1 w-full flex flex-col justify-start items-center min-h-0 pr-[env(safe-area-inset-right)] pl-[env(safe-area-inset-left)] md:pl-0">
+      <main className="flex h-full min-w-0 flex-1 flex-col overflow-clip">
+        <div className="flex min-h-0 w-full flex-1 flex-col items-center justify-start pr-[env(safe-area-inset-right)] pl-[env(safe-area-inset-left)] md:pl-0">
           {children}
         </div>
         <MobileNavBarPlaceholder />

--- a/src/components/secret-drawer.tsx
+++ b/src/components/secret-drawer.tsx
@@ -38,12 +38,12 @@ export const SecretDrawer: FC<SecretDrawerProps> = ({ isOpen, onOpenChange }) =>
             their variant combinations.
           </DrawerDescription>
         </DrawerHeader>
-        <div className="p-4 flex flex-col items-center">
-          <p className="text-center mb-4">
+        <div className="flex flex-col items-center p-4">
+          <p className="mb-4 text-center">
             You unlocked this secret feature by clicking the settings button 5 times in a row. Click the button below to
             visit the Demo page.
           </p>
-          <div className="w-full max-w-md mx-auto">
+          <div className="mx-auto w-full max-w-md">
             <Button onClick={handleNavigateToDemo} className="w-full">
               Go to Demo Page
             </Button>

--- a/src/components/theme/theme-toggle.tsx
+++ b/src/components/theme/theme-toggle.tsx
@@ -28,17 +28,17 @@ export const ThemeToggle: FC = () => {
           {mounted ? (
             <>
               <Sun
-                className={cn('h-[1.2rem] w-[1.2rem] absolute opacity-0', {
+                className={cn('absolute h-[1.2rem] w-[1.2rem] opacity-0', {
                   'opacity-100': theme === 'light',
                 })}
               />
               <Moon
-                className={cn('h-[1.2rem] w-[1.2rem] absolute opacity-0', {
+                className={cn('absolute h-[1.2rem] w-[1.2rem] opacity-0', {
                   'opacity-100': theme === 'dark',
                 })}
               />
               <Laptop
-                className={cn('h-[1.2rem] w-[1.2rem] absolute opacity-0', {
+                className={cn('absolute h-[1.2rem] w-[1.2rem] opacity-0', {
                   'opacity-100': theme === 'system',
                 })}
               />


### PR DESCRIPTION
## Changes
Adjust Prettier Plugin Order
   - Move `prettier-plugin-tailwindcss` to the end of plugins array to ensure proper functionality
   - Keep `prettier-plugin-sort-imports` before it
   - Run `lint --fix` to solve existing proplems

## Rationale
- `prettier-plugin-tailwindcss` needs to run after other plugins to correctly identify and sort Tailwind classes
- Unified import sorting rules improve code readability and maintainability

## Testing
- [x] Prettier formatting works as expected
- [x] Tailwind classes are properly sorted
- [x] Import statements are grouped and sorted correctly

## Related Documentation
- [prettier-plugin-tailwindcss docs](https://github.com/tailwindlabs/prettier-plugin-tailwindcss)
- [prettier-plugin-sort-imports docs](https://github.com/trivago/prettier-plugin-sort-imports)